### PR TITLE
Basic roles for plain users and teachers

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -3,7 +3,10 @@
 class Registration < ApplicationRecord
   class AlreadyCreatedError < StandardError; end
 
+  class NotAllowedError < StandardError; end
+
   class CreationError < StandardError; end
+
   belongs_to :user
   belongs_to :course
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,5 +12,8 @@ class User < ApplicationRecord
             format: { with: URI::MailTo::EMAIL_REGEXP },
             presence: true
 
+  enum role: %i[user teacher]
+  validates :role, presence: true
+
   acts_as_votable
 end

--- a/app/services/registration_request.rb
+++ b/app/services/registration_request.rb
@@ -9,8 +9,10 @@ class RegistrationRequest
   end
 
   def call
-    course = Course.find_or_create_by!(title: title)
     user = User.find(user_id)
+    raise_not_allowed_error unless user.teacher?
+
+    course = Course.find_or_create_by!(title: title)
 
     existing_registration = Registration.find_by(user_id: user.id, course_id: course.id)
     raise_already_created_error if existing_registration
@@ -30,5 +32,9 @@ class RegistrationRequest
 
   def raise_creation_error
     raise Registration::CreationError, 'Error creating a new registration'
+  end
+
+  def raise_not_allowed_error
+    raise Registration::NotAllowedError, 'you must have the teacher role to perform this action'
   end
 end

--- a/db/migrate/20210417053917_add_roles_to_users.rb
+++ b/db/migrate/20210417053917_add_roles_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRolesToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_416_124_411) do
+ActiveRecord::Schema.define(version: 20_210_417_053_917) do
   create_table 'courses', charset: 'utf8', force: :cascade do |t|
     t.string 'title'
     t.datetime 'created_at', precision: 6, null: false
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20_210_416_124_411) do
     t.string 'email'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'role', default: 0
     t.index ['email'], name: 'index_users_on_email', unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
+    role 1
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_uniqueness_of(:email) }
     it { should allow_value('email@addresse.foo').for(:email) }
     it { should_not allow_value('foo').for(:email) }
+    it { is_expected.to validate_presence_of(:role) }
+    it { is_expected.to allow_values(:user, :teacher).for(:role) }
   end
 
   context 'db configuration' do


### PR DESCRIPTION
The solution for the user vs teacher scenario didn't feel right.
It should have been solved at a controller level, just in a before action, to spot the role of the user doing the request, so it could be unauthorized at that point. But the again this would work much better when using some authentication.

I added the role feature to the User model, to be able to spot who is trying to create a registration, since that action should only be allowed for users with the teacher role.
This way at least I can show a better error message to the user.

